### PR TITLE
Fix: Activate sound when device is on vibrate mode (iOS)

### DIFF
--- a/ios/thinkerview/AppDelegate.m
+++ b/ios/thinkerview/AppDelegate.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <AVFoundation/AVFoundation.h>
 
 @implementation AppDelegate
 
@@ -29,6 +30,9 @@
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  
+  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error: nil];
+  
   return YES;
 }
 


### PR DESCRIPTION
Update to allow the sound (Youtube player or Audio) when the device(iOS) is on Vibrate mode.